### PR TITLE
Renamed example .env

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,5 @@
+# This is a sample .env file. You should copy this file to .env.local (or .env.development.local) and change the values to your own.
+DB_HOST=localhost
+DB_SCHEMA=showcase
+DB_USER=root
+DB_PW=root

--- a/.gitignore
+++ b/.gitignore
@@ -3,9 +3,7 @@ node_modules
 /build
 /.svelte-kit
 /package
-.env
-.env.*
-!.env.example
+.env*.local
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
 /static/css/smui*.css


### PR DESCRIPTION
We need a .env file for building with GitHub actions, so the example .env file now also serves as a build dummy. The changes are also reflected in the .gitignore file, now handling .env files [as intended by Vite](https://vitejs.dev/guide/env-and-mode.html#env-files).